### PR TITLE
 Remove trailing zeroes from decimal numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function joinNumbers(digits, ...numbers) {
     if (i > 0 && v >= 0) {
       s += ',';
     }
-    s += v.toFixed(digits);
+    s += parseFloat(v.toFixed(digits)).toString();
   }
   return s;
 }


### PR DESCRIPTION
Hi! Thank you for creating this library. I noticed a problem using it when `precision` is set to anything above `0`. So, I made a small change to remove trailing zeroes from decimal numbers in the output paths. This change serves two purposes:

1) The output path will be smaller.
2) Paths that include the `A` command will no longer cause some renderers to fail. Previously, the "large-arc" and "sweep" flags were being set to `0.0` instead of `0` and causing some renderers to fail.

For example, try [testing the following SVG path](https://naiksoftware.github.io/svg.html) (tested in Firefox and Edge w/ WebKit):

`M11,0H5A1,1,0,0,0,4,1V4H6V2H10V10H6V8H4V11A1,1,0,0,0,5,12H11A1,1,0,0,0,12,11V1A1,1,0,0,0,11,0zM8,5H3V3L0,6L3,9V7H8V5`

This works. Now try changing one inconspicuous `0` to `0.0`:

`M11,0H5A1,1,0,0.0,0,4,1V4H6V2H10V10H6V8H4V11A1,1,0,0,0,5,12H11A1,1,0,0,0,12,11V1A1,1,0,0,0,11,0zM8,5H3V3L0,6L3,9V7H8V5`

This now doesn't work.

If this change is accepted, you may also consider changing the default `precision` from `0` to something moderate like `4`, since trailing zeroes will no longer inflate the output size unnecessarily, and this extra default precision would help the library work better for a wider range of inputs.

Thanks again for your hard work and thanks for reading!